### PR TITLE
fill in missing flavor text and illustrators

### DIFF
--- a/json/PackCard/fate-has-no-secrets.json
+++ b/json/PackCard/fate-has-no-secrets.json
@@ -1,160 +1,160 @@
 [
     {
         "card_id": "massing-at-twilight",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Niten",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_81.jpg",
         "position": "81",
         "quantity": 3
     },
     {
         "card_id": "crisis-breaker",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Niten",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_82.jpg",
         "position": "82",
         "quantity": 3
     },
     {
         "card_id": "yasuki-taka",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"I find the best use of my mouth is to bargain with it.\"",
+        "illustrator": "Borja Pindado",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_83.jpg",
         "position": "83",
         "quantity": 3
     },
     {
         "card_id": "origami-master",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Shen Fei",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_84.jpg",
         "position": "84",
         "quantity": 3
     },
     {
         "card_id": "itinerant-philosopher",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"A student must learn every falsehood before they can learn the truth.\"",
+        "illustrator": "Niten",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_85.jpg",
         "position": "85",
         "quantity": 3
     },
     {
         "card_id": "miwaku-kabe-guard",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"This wall is as unassailable as the honor of the Lion.\"",
+        "illustrator": "Samuel Leung",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_86.jpg",
         "position": "86",
         "quantity": 3
     },
     {
         "card_id": "henshin-disciple",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Carlos Palma Cruchaga",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_87.jpg",
         "position": "87",
         "quantity": 3
     },
     {
         "card_id": "master-of-gisei-toshi",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "There are strict rules regarding the behavior of guests. There have never been any guests.",
+        "illustrator": "Joyce Maureira",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_88.jpg",
         "position": "88",
         "quantity": 3
     },
     {
         "card_id": "moto-juro",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"I will follow you, and they will follow me. Even into Jigoku itself.\"",
+        "illustrator": "Calvin Chua",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_89.jpg",
         "position": "89",
         "quantity": 3
     },
     {
         "card_id": "seppun-ishikawa",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"You are not worthy of her, Toturi-sama.\"",
+        "illustrator": "Diego Gisbert Llorens",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_90.jpg",
         "position": "90",
         "quantity": 3
     },
     {
         "card_id": "fair-accord",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"So long as there is the light of 'I want to make a deal,' even the most painful negotiations will eventually pay off.\" – Yasuki Taka, the Wily Trader",
+        "illustrator": "Felipe Gaona",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_91.jpg",
         "position": "91",
         "quantity": 3
     },
     {
         "card_id": "young-harrier",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "To do what we must.",
+        "illustrator": "Felipe Gaona",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_92.jpg",
         "position": "92",
         "quantity": 3
     },
     {
         "card_id": "test-of-skill",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Oscar Römer",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_93.jpg",
         "position": "93",
         "quantity": 3
     },
     {
         "card_id": "the-stone-of-sorrows",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "There is no sorrow greater than wisdom.",
+        "illustrator": "Antonio José Manzanedo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_94.jpg",
         "position": "94",
         "quantity": 3
     },
     {
         "card_id": "seal-of-the-lion",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "In the name of His Excellency,\nthe Right Hand of the Emperor,\nHigh General,\nChampion of the Lion,andnDaimyō of the Akodo,Toturi, son of Daio,\nson of Kozue, daughter of Yokutsune...",
+        "illustrator": "Mauro Dal Bo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_95.jpg",
         "position": "95",
         "quantity": 3
     },
     {
         "card_id": "consumed-by-five-fires",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"By these fires be cleansed.\" – Isawa Masahiro",
+        "illustrator": "Antonio José Manzanedo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_96.jpg",
         "position": "96",
         "quantity": 3
     },
     {
         "card_id": "cunning-magistrate",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"Let them fear the law and be better for it.\"",
+        "illustrator": "Niten",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_97.jpg",
         "position": "97",
         "quantity": 3
     },
     {
         "card_id": "a-fate-worse-than-death",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Antonio José Manzanedo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_98.jpg",
         "position": "98",
         "quantity": 3
     },
     {
         "card_id": "ride-them-down",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"We will bring the war to the Lion.\" – Moto Juro",
+        "illustrator": "Calvin Chua",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_99.jpg",
         "position": "99",
         "quantity": 3
     },
     {
         "card_id": "waning-hostilities",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"Knowing your advantages does you no good if your enemy is able to keep you from employing them.\" – Tao of Shinsei",
+        "illustrator": "Filip Storch",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C06_100.jpg",
         "position": "100",
         "quantity": 3

--- a/json/PackCard/for-honor-and-glory.json
+++ b/json/PackCard/for-honor-and-glory.json
@@ -1,7 +1,7 @@
 [
     {
         "card_id": "bayushi-yojiro",
-        "flavor": null,
+        "flavor": "\"If you will not believe a word I say, I may as well tell the truth.\"",
         "illustrator": "Carlos Palma Cruchaga",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_28.jpg",
         "position": "28",
@@ -33,7 +33,7 @@
     },
     {
         "card_id": "ide-tadaji",
-        "flavor": null,
+        "flavor": "\"Without a worthy opponent, victory is meaningless.\"",
         "illustrator": "Polar Engine",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_29.jpg",
         "position": "29",
@@ -41,7 +41,7 @@
     },
     {
         "card_id": "ikoma-ujiaki",
-        "flavor": null,
+        "flavor": "\"I remember.\"",
         "illustrator": "Diego Gisbert Llorens",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_26.jpg",
         "position": "26",
@@ -49,7 +49,7 @@
     },
     {
         "card_id": "kabuki-hero",
-        "flavor": null,
+        "flavor": "\"As a tear of dew on a fallen leaf –\nas the glimmer of moonlight on a still lake –\nsuch is the impermanence of this life.\"\n – Asahina Ichikawa",
         "illustrator": "Jason Juta",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_24.jpg",
         "position": "24",
@@ -129,7 +129,7 @@
     },
     {
         "card_id": "seal-of-the-scorpion",
-        "flavor": null,
+        "flavor": "In the name of Lord Bayushi Shoju,\nthe Most Dutiful,\nMaster of Secrets,\namong other titles known and unknown,\nDaimyō of the Bayushi, and\nChampion of the Scorpion Clan",
         "illustrator": "Mauro Dal Bo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_38.jpg",
         "position": "38",
@@ -137,7 +137,7 @@
     },
     {
         "card_id": "shinjo-saddle",
-        "flavor": null,
+        "flavor": "Among the Unicorn, one inherits more than just a daishō.",
         "illustrator": "Jason Juta",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_39.jpg",
         "position": "39",
@@ -145,7 +145,7 @@
     },
     {
         "card_id": "shrine-maiden",
-        "flavor": null,
+        "flavor": "\"My family has protected this shrine for generations, and we shall protect it for generations more.\"",
         "illustrator": "Shen Fei",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_36.jpg",
         "position": "36",
@@ -153,7 +153,7 @@
     },
     {
         "card_id": "stoic-magistrate",
-        "flavor": null,
+        "flavor": "\"There is no justice. There is just us.\"",
         "illustrator": "Stanislav Dikolenko",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C03_23.jpg",
         "position": "23",

--- a/json/PackCard/meditations-on-the-ephemeral.json
+++ b/json/PackCard/meditations-on-the-ephemeral.json
@@ -1,160 +1,160 @@
 [
     {
         "card_id": "along-the-river-of-gold",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Alayna Lemmer",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_101.jpg",
         "position": "101",
         "quantity": 3
     },
     {
         "card_id": "kuni-ritsuko",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"The kami of earth abhor corruption even more than we do. Their aid is ours for the asking.\"",
+        "illustrator": "Shen Fei",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_102.jpg",
         "position": "102",
         "quantity": 3
     },
     {
         "card_id": "iron-mine",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Stanislav Dikolenko",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_103.jpg",
         "position": "103",
         "quantity": 3
     },
     {
         "card_id": "silver-tongued-magistrate",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"A beautiful Empire can only be built upon beautiful laws.\"",
+        "illustrator": "Jason Juta",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_104.jpg",
         "position": "104",
         "quantity": 3
     },
     {
         "card_id": "togashi-mendicant",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"It was but a little I spent to save the kit, but had it cost a Fortune I would not have grudged it.\"",
+        "illustrator": "Leanna Crossan",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_105.jpg",
         "position": "105",
         "quantity": 3
     },
     {
         "card_id": "beastmaster-matriarch",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"I have always heard that the Lion’s greatest weapon is their pride.\" – Ikoma Ikehata",
+        "illustrator": "Halil Ural",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_106.jpg",
         "position": "106",
         "quantity": 3
     },
     {
         "card_id": "asako-tsuki",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"History is fixed, but the future flows.\"",
+        "illustrator": "Lin Hsiang",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_107.jpg",
         "position": "107",
         "quantity": 3
     },
     {
         "card_id": "kanjo-district",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Nele Diel",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_108.jpg",
         "position": "108",
         "quantity": 3
     },
     {
         "card_id": "sake-house-confidant",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"Would you like to concede?\"",
+        "illustrator": "Borja Pindado",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_109.jpg",
         "position": "109",
         "quantity": 3
     },
     {
         "card_id": "illustrious-plagiarist",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"All good artists borrow. I am a great artist.\"",
+        "illustrator": "Jorge Matar",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_110.jpg",
         "position": "110",
         "quantity": 3
     },
     {
         "card_id": "shinjo-scout",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"The Scorpion have eyes in every court. We have eyes everywhere else.\"",
+        "illustrator": "Leanna Crossan",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_111.jpg",
         "position": "111",
         "quantity": 3
     },
     {
         "card_id": "miya-satoshi",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"You who would speak to the Son of Heaven would do well to speak first to me.\"",
+        "illustrator": "Gong Studios",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_112.jpg",
         "position": "112",
         "quantity": 3
     },
     {
         "card_id": "pillow-book",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Joyce Maureira",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_113.jpg",
         "position": "113",
         "quantity": 3
     },
     {
         "card_id": "seal-of-the-dragon",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "In the name of Togashi Yokuni,\nthe Enlightened,\nMaster of the High House of Light, and\nChampion of the Dragon Clan",
+        "illustrator": "Mauro Dal Bo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_114.jpg",
         "position": "114",
         "quantity": 3
     },
     {
         "card_id": "written-in-the-stars",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "\"The time has come.\" – Togashi Mitsu",
+        "illustrator": "Pavel Kolomeyets",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_115.jpg",
         "position": "115",
         "quantity": 3
     },
     {
         "card_id": "a-legion-of-one",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Borja Pindado",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_116.jpg",
         "position": "116",
         "quantity": 3
     },
     {
         "card_id": "oni-mask",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Felipe Gaona",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_117.jpg",
         "position": "117",
         "quantity": 3
     },
     {
         "card_id": "seal-of-the-unicorn",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "In the name of Lady Shinjo Altansarnai,\nSeeker of the Setting Sun,\nKhan of Khans,\nMistress of the Five Winds,\nDaimyō of the Shinjo, and\nChampion of the Unicorn Clan",
+        "illustrator": "Mauro Dal Bo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_118.jpg",
         "position": "118",
         "quantity": 3
     },
     {
         "card_id": "talisman-of-the-sun",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": null,
+        "illustrator": "Calvin Chua",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_119.jpg",
         "position": "119",
         "quantity": 3
     },
     {
         "card_id": "mono-no-aware",
-        "flavor": "",
-        "illustrator": "",
+        "flavor": "Autumn’s voice falters\nVisions of days together\nFade with the new snow",
+        "illustrator": "Kevin Zamir Goeke",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C07_120.jpg",
         "position": "120",
         "quantity": 3

--- a/json/PackCard/the-chrysanthemum-throne.json
+++ b/json/PackCard/the-chrysanthemum-throne.json
@@ -1,7 +1,7 @@
 [
     {
         "card_id": "agasha-sumiko",
-        "flavor": null,
+        "flavor": "\"I will not merely record history. I will forge it myself.\"",
         "illustrator": "Lin Hsiang",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_65.jpg",
         "position": "65",
@@ -9,7 +9,7 @@
     },
     {
         "card_id": "akodo-toshiro",
-        "flavor": null,
+        "flavor": "\"You are the most gifted swordsman of your generation. Why must you waste your time on this cowardly art?\" Akodo Gendo",
         "illustrator": "Stanislav Dikolenko",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_67.jpg",
         "position": "67",
@@ -17,7 +17,7 @@
     },
     {
         "card_id": "backhanded-compliment",
-        "flavor": null,
+        "flavor": "\"No one could accuse you of vanity with such a style.\"",
         "illustrator": "Tropa Entertainment",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_78.jpg",
         "position": "78",
@@ -25,7 +25,7 @@
     },
     {
         "card_id": "before-the-throne",
-        "flavor": null,
+        "flavor": "\"Your August Imperial Majesty, your humble servant comes before you...\"",
         "illustrator": "Nele Diel",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_61.jpg",
         "position": "61",
@@ -41,7 +41,7 @@
     },
     {
         "card_id": "curry-favor",
-        "flavor": null,
+        "flavor": "\"How could the Crane do any less for our honored allies?\"",
         "illustrator": "Hai Hoang",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_74.jpg",
         "position": "74",
@@ -49,7 +49,7 @@
     },
     {
         "card_id": "doji-shizue",
-        "flavor": null,
+        "flavor": "\"Mukashi mukashi...\"",
         "illustrator": "Borja Pindado",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_64.jpg",
         "position": "64",
@@ -57,7 +57,7 @@
     },
     {
         "card_id": "fawning-diplomat",
-        "flavor": null,
+        "flavor": "Flattery is the currency of the court.",
         "illustrator": "Giby Joseph",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_70.jpg",
         "position": "70",
@@ -65,7 +65,7 @@
     },
     {
         "card_id": "gaijin-customs",
-        "flavor": null,
+        "flavor": "They stood, unmoving, each unsure how to proceed.",
         "illustrator": "Tropa Entertainment",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_79.jpg",
         "position": "79",
@@ -73,7 +73,7 @@
     },
     {
         "card_id": "guard-duty",
-        "flavor": null,
+        "flavor": "\"But mother,\" said the young Lion, \"how am I to find glory if I remain behind?\"\n\"You will find honor,\" said his mother. \"And a Lion requires nothing more.\" – Ikoma's Chronicles",
         "illustrator": "Piotr Arendzikowski",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_76.jpg",
         "position": "76",
@@ -89,7 +89,7 @@
     },
     {
         "card_id": "haughty-magistrate",
-        "flavor": null,
+        "flavor": "\"There is the Tao and there is the Law. Both are the same under Heaven.\"",
         "illustrator": "Hai Hoang",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_69.jpg",
         "position": "69",
@@ -97,7 +97,7 @@
     },
     {
         "card_id": "implacable-magistrate",
-        "flavor": null,
+        "flavor": "\"A failure before the law is a failure of honor.\"",
         "illustrator": "Tropa Entertainment",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_68.jpg",
         "position": "68",
@@ -105,7 +105,7 @@
     },
     {
         "card_id": "kaiu-inventor",
-        "flavor": null,
+        "flavor": "\"It will work...eventually.\"",
         "illustrator": "Stanislav Dikolenko",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_63.jpg",
         "position": "63",
@@ -121,7 +121,7 @@
     },
     {
         "card_id": "pit-trap",
-        "flavor": null,
+        "flavor": "\"My apologies, samurai-san. That pit was intended for goblins.\" – Kaiu Shuichi",
         "illustrator": "Stanislav Dikolenko",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_73.jpg",
         "position": "73",
@@ -129,7 +129,7 @@
     },
     {
         "card_id": "seal-of-the-phoenix",
-        "flavor": null,
+        "flavor": "In the name of Lady Shiba Tsukune,\nthe Soul of Shiba,\nProtector of the Council,\nKeeper of the Tao,\nDaimyō of the Shiba, and\nChampion of the Phoenix Clan",
         "illustrator": "Mauro Dal Bo",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_77.jpg",
         "position": "77",
@@ -145,7 +145,7 @@
     },
     {
         "card_id": "utaku-mediator",
-        "flavor": null,
+        "flavor": "\"It is difficult to speak clearly to those who have seen so little of the world.\"",
         "illustrator": "Giby Joseph",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_71.jpg",
         "position": "71",
@@ -153,7 +153,7 @@
     },
     {
         "card_id": "way-of-the-chrysanthemum",
-        "flavor": null,
+        "flavor": "As Lady Sun's brilliance illuminates the land, so too does her chosen son radiate peace and prosperity to all Rokugan.",
         "illustrator": "Francesca Baerald",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C05_80.jpg",
         "position": "80",


### PR DESCRIPTION
all main set releases should now have illustrator and flavor fields filled in.  Text came from CGDB. 