### PR TITLE
fix Shiba Tetsu card position number

### DIFF
--- a/json/PackCard/disciples-of-the-void.json
+++ b/json/PackCard/disciples-of-the-void.json
@@ -44,7 +44,7 @@
         "flavor": "All that matters is that I server my clan as best I am able.",
         "illustrator": "Ignatius Budi",
         "image_url": "http://lcg-cdn.fantasyflightgames.com/l5r/L5C08_6.jpg",
-        "position": "3",
+        "position": "6",
         "quantity": 3
     },
 


### PR DESCRIPTION
card position number for Shiba Tetsu, which collided with Support of the Phoenix.  Should be 6.