### PR TITLE
CotE - Student of War

### DIFF
--- a/json/Card/student-of-war.json
+++ b/json/Card/student-of-war.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "lion",
+        "cost": 3,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": 1,
+        "honor": null,
+        "id": "student-of-war",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": "3",
+        "military_bonus": null,
+        "name": "Student of War",
+        "name_extra": null,
+        "political": "2",
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "dynasty",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "Composure - This character cannot lose fate or be discarded.  (You have composure if your honor bid is lower than an opponent's.)",
+        "traits": [
+            "bushi"
+        ],
+        "type": "character",
+        "unicity": false
+    }
+]

--- a/json/Card/student-of-war.json
+++ b/json/Card/student-of-war.json
@@ -1,30 +1,30 @@
 [
-    {
-        "clan": "lion",
-        "cost": 3,
-        "deck_limit": 3,
-        "element": null,
-        "fate": null,
-        "glory": 1,
-        "honor": null,
-        "id": "student-of-war",
-        "influence_cost": null,
-        "influence_pool": null,
-        "military": "3",
-        "military_bonus": null,
-        "name": "Student of War",
-        "name_extra": null,
-        "political": "2",
-        "political_bonus": null,
-        "role_restriction": null,
-        "side": "dynasty",
-        "strength": null,
-        "strength_bonus": null,
-        "text": "Composure - This character cannot lose fate or be discarded.  (You have composure if your honor bid is lower than an opponent's.)",
-        "traits": [
-            "bushi"
-        ],
-        "type": "character",
-        "unicity": false
-    }
+  {
+    "clan": "lion",
+    "cost": 3,
+    "deck_limit": 3,
+    "element": null,
+    "fate": null,
+    "glory": 1,
+    "honor": null,
+    "id": "student-of-war",
+    "influence_cost": null,
+    "influence_pool": null,
+    "military": "3",
+    "military_bonus": null,
+    "name": "Student of War",
+    "name_extra": null,
+    "political": "2",
+    "political_bonus": null,
+    "role_restriction": null,
+    "side": "dynasty",
+    "strength": null,
+    "strength_bonus": null,
+    "text": "Composure - This character cannot lose fate or be discarded.  <i>(You have composure if your honor bid is lower than an opponent's.)</i>",
+    "traits": [
+      "bushi"
+    ],
+    "type": "character",
+    "unicity": false
+  }
 ]


### PR DESCRIPTION
Hi,

We are starting implementation of spoiled cards from Children of the Empire on Jigoku (ringteki).  As ringteki is dependent of the data provided by fiveringsdb - this is a bit of a test run to see if creating some PRs for CotE will be accepted.

A few points:

* I have only added the student-of-war.json file and have not looked at anything in the PackCard folder so not sure if this will break anything.  Ringteki is only relying on the card json for us to test implementation.
* This is obviously not a released card yet.  I'm not sure if you would like to have a property on the card (or pack maybe) in order to indicate that.
* I'm requesting to pull into master (not develop) as that looked as though it is stale.  If you wanted to start up a branch for CotE that could maybe work as well.

If this is ok, please let me know and then further PRs can be made for the rest of the spoiled cards.