### PR TITLE
Masters of the Court (spoilers from 2019-01-09)

### DIFF
--- a/json/Card/akodo-makoto.json
+++ b/json/Card/akodo-makoto.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "lion",
+        "cost": 3,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": 1,
+        "honor": null,
+        "id": "akodo-makoto",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": "4",
+        "military_bonus": null,
+        "name": "Akodo Makoto",
+        "name_extra": null,
+        "political": "1",
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "dynasty",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "<b>Reaction:</b> After this character wins a conflict, choose a participating <em>Courtier</em> character - if that character has no fate on it, discard it. Otherwise, remove 1 fate from it.",
+        "traits": [
+            "bushi"
+        ],
+        "type": "character",
+        "unicity": true
+    }
+]

--- a/json/Card/asahina-takamori.json
+++ b/json/Card/asahina-takamori.json
@@ -1,0 +1,33 @@
+[
+    {
+        "clan": "crane",
+        "cost": 4,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": 3,
+        "honor": null,
+        "id": "asahina-takamori",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": "0",
+        "military_bonus": null,
+        "name": "Asahina Takamori",
+        "name_extra": null,
+        "political": "0",
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "dynasty",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "<b>Reaction: After you play a [clan-crane] character, choose an opponent's character with equal or lower printed cost - that character cannot be declared as an attacker or defender this round.</b> ",
+        "traits": [
+            "courtier",
+            "shugenja",
+            "air",
+            "daimyo"
+        ],
+        "type": "character",
+        "unicity": true
+    }
+]

--- a/json/Card/distinguished-dojo.json
+++ b/json/Card/distinguished-dojo.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "crane",
+        "cost": null,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": null,
+        "honor": null,
+        "id": "distinguished-dojo",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": null,
+        "military_bonus": null,
+        "name": "Distinguished Dōjō",
+        "name_extra": null,
+        "political": null,
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "dynasty",
+        "strength": null,
+        "strength_bonus": "+2",
+        "text": "<b>Reaction:</b> After you win a duel - place 1 honor token on this holding. Then, you may sacrifice this holding to gain honor equal to the number of honor tokens on this holding. (Limit 3 times per round.)",
+        "traits": [
+            "dojo"
+        ],
+        "type": "holding",
+        "unicity": false
+    }
+]

--- a/json/Card/gossip.json
+++ b/json/Card/gossip.json
@@ -8,7 +8,7 @@
         "glory": null,
         "honor": null,
         "id": "gossip",
-        "influence_cost": 0,
+        "influence_cost": null,
         "influence_pool": null,
         "military": null,
         "military_bonus": null,

--- a/json/Card/gossip.json
+++ b/json/Card/gossip.json
@@ -1,0 +1,28 @@
+[
+    {
+        "clan": "crane",
+        "cost": 0,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": null,
+        "honor": null,
+        "id": "gossip",
+        "influence_cost": 0,
+        "influence_pool": null,
+        "military": null,
+        "military_bonus": null,
+        "name": "Gossip",
+        "name_extra": null,
+        "political": null,
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "conflict",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "Limited. <i>(No more than one limited card can be played by each player each round.)</i>\n...",
+        "traits": [],
+        "type": "event",
+        "unicity": false
+    }
+]

--- a/json/Card/kakita-yuri.json
+++ b/json/Card/kakita-yuri.json
@@ -1,0 +1,31 @@
+[
+    {
+        "clan": "crane",
+        "cost": 3,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": 2,
+        "honor": null,
+        "id": "kakita-yuri",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": "3",
+        "military_bonus": null,
+        "name": "Kakita Yuri",
+        "name_extra": null,
+        "political": "0",
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "dynasty",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "<b>Action:</b> During a conflict, initiate a [conflict-political] duel against a character your opponent controls of his or her choice - resolve the duel. The controller of the duel's loser cannot declare [conflict-military] conflicts this phase.",
+        "traits": [
+            "courtier",
+            "duelist"
+        ],
+        "type": "character",
+        "unicity": true
+    }
+]

--- a/json/Card/kyuden-kakita.json
+++ b/json/Card/kyuden-kakita.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "crane",
+        "cost": null,
+        "deck_limit": 1,
+        "element": null,
+        "fate": 7,
+        "glory": null,
+        "honor": 11,
+        "id": "kyuden-kakita",
+        "influence_cost": null,
+        "influence_pool": 9,
+        "military": null,
+        "military_bonus": null,
+        "name": "Kyūden Kakita",
+        "name_extra": null,
+        "political": null,
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "province",
+        "strength": null,
+        "strength_bonus": "+1",
+        "text": "<b>Reaction:</b> After a duel resolves, bow this stronghold and choose a character you control that was involved in the duel - honor that character.",
+        "traits": [
+            "palace"
+        ],
+        "type": "stronghold",
+        "unicity": true
+    }
+]

--- a/json/Card/political-sanction.json
+++ b/json/Card/political-sanction.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "crane",
+        "cost": 0,
+        "deck_limit": 3,
+        "element": null,
+        "fate": null,
+        "glory": null,
+        "honor": null,
+        "id": "political-sanction",
+        "influence_cost": 1,
+        "influence_pool": null,
+        "military": null,
+        "military_bonus": "+0",
+        "name": "Polital Sanction",
+        "name_extra": null,
+        "political": null,
+        "political_bonus": "+0",
+        "role_restriction": null,
+        "side": "conflict",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "Play only during a [conflict-political] conflict, in which you count more current [conflict-political] than your opponent, and only on a participating character.\nAttached character cannot trigger its abilities.",
+        "traits": [
+            "condition"
+        ],
+        "type": "attachment",
+        "unicity": false
+    }
+]

--- a/json/Card/political-sanction.json
+++ b/json/Card/political-sanction.json
@@ -12,7 +12,7 @@
         "influence_pool": null,
         "military": null,
         "military_bonus": "+0",
-        "name": "Polital Sanction",
+        "name": "Political Sanction",
         "name_extra": null,
         "political": null,
         "political_bonus": "+0",

--- a/json/Card/support-of-the-crane.json
+++ b/json/Card/support-of-the-crane.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clan": "neutral",
+        "cost": null,
+        "deck_limit": 1,
+        "element": null,
+        "fate": null,
+        "glory": null,
+        "honor": null,
+        "id": "support-of-the-crane",
+        "influence_cost": null,
+        "influence_pool": null,
+        "military": null,
+        "military_bonus": null,
+        "name": "Support of the Crane",
+        "name_extra": null,
+        "political": null,
+        "political_bonus": null,
+        "role_restriction": null,
+        "side": "role",
+        "strength": null,
+        "strength_bonus": null,
+        "text": "Increase your deckbuilding influence value by 8. You may only spend influence on [clan-crane] clan cards.",
+        "traits": [
+            "crane"
+        ],
+        "type": "role",
+        "unicity": false
+    }
+]

--- a/json/Label/en.json
+++ b/json/Label/en.json
@@ -140,6 +140,10 @@
         "value": "Courtier"
     },
     {
+        "id": "trait.crane",
+        "value": "Crane"
+    },
+    {
         "id": "trait.creature",
         "value": "Creature"
     },
@@ -172,12 +176,12 @@
         "value": "Engineer"
     },
     {
-        "id": "trait.fire",
-        "value": "Fire"
-    },
-    {
         "id": "trait.festival",
         "value": "Festival"
+    },
+    {
+        "id": "trait.fire",
+        "value": "Fire"
     },
     {
         "id": "trait.follower",

--- a/json/Pack.json
+++ b/json/Pack.json
@@ -178,5 +178,14 @@
         "released_at": "2018-04-01",
         "ffg_id": "L5C17",
         "cycle_id": "clan-packs"
+    },
+    {
+        "id": "masters-of-the-court",
+        "name": "Masters of the Court",
+        "position": 4,
+        "size": 28,
+        "released_at": "2018-04-01",
+        "ffg_id": "L5C18",
+        "cycle_id": "clan-packs"
     }
 ]

--- a/json/PackCard/masters-of-the-court.json
+++ b/json/PackCard/masters-of-the-court.json
@@ -1,0 +1,66 @@
+[
+    {
+        "card_id": "kyuden-kakita",
+        "flavor": "",
+        "illustrator": "Nele Diel",
+        "image_url": "",
+        "position": "1",
+        "quantity": 1
+    },
+    {
+        "card_id": "support-of-the-crane",
+        "flavor": "",
+        "illustrator": "",
+        "image_url": "",
+        "position": "3",
+        "quantity": 1
+    },
+    {
+        "card_id": "kakita-yuri",
+        "flavor": "",
+        "illustrator": "Filipe Gaona",
+        "image_url": "",
+        "position": "8",
+        "quantity": 3
+    },
+    {
+        "card_id": "asahina-takamori",
+        "flavor": "\"A red sun in the hour of the Hare. Not a bird in the sky. Do you not see that the battle is already won?\"",
+        "illustrator": "Lin Hsiang",
+        "image_url": "",
+        "position": "9",
+        "quantity": 3
+    },
+    {
+        "card_id": "distinguished-dojo",
+        "flavor": "",
+        "illustrator": "Matt Bulahao",
+        "image_url": "",
+        "position": "13",
+        "quantity": 3
+    },
+    {
+        "card_id": "akodo-makoto",
+        "flavor": "\"I am sworn to the Lion. My former husband's acts with the Crane army are non of your concern.\"",
+        "illustrator": "Borja-Pindado",
+        "image_url": "",
+        "position": "16",
+        "quantity": 3
+    },
+    {
+        "card_id": "political-sanction",
+        "flavor": "",
+        "illustrator": "Lukas Banas",
+        "image_url": "",
+        "position": "20",
+        "quantity": 3
+    },
+    {
+        "card_id": "gossip",
+        "flavor": "",
+        "illustrator": "",
+        "image_url": "",
+        "position": "21",
+        "quantity": 3
+    }
+]


### PR DESCRIPTION
Adds:
- All 6 new spoiled cards from https://www.fantasyflightgames.com/en/news/2019/1/9/masters-of-the-court/
- Gossip as incomplete spoiler
- Support of the Crane (because it will be there)

- Masters of the Court to the "clanpack" cycle
- Pack information for the cards in the pack